### PR TITLE
feat/pokemon cmd

### DIFF
--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -1,24 +1,22 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sanka047/pokedex-go/testing/assert"
+)
 
 func TestExitHappyPath(t *testing.T) {
 	e := NewExit()
 	res, err := e.Cmd([]string{})
-	if err != nil {
-		t.FailNow()
-	}
+	assert.Ok(t, err)
 
 	exp := Result{IsTerminal: true}
-	if res != exp {
-		t.Fatalf("Expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", exp, res)
-	}
+	assert.Equals(t, res, exp)
 }
 
 func TestExitExtraArgs(t *testing.T) {
 	e := NewExit()
 	_, err := e.Cmd([]string{"a", "b"})
-	if err == nil {
-		t.FailNow()
-	}
+	assert.Err(t, err)
 }

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/sanka047/pokedex-go/testing/assert"
 )
 
 type StubCmd1 struct{}
@@ -27,34 +29,21 @@ func TestHelpHappyPath(t *testing.T) {
 	}
 	h := NewHelp(cmds)
 
-	if h.mesg != nil {
-		t.Fatal("There is an existing cached value in h.mesg")
-	}
+	assert.Equals(t, h.mesg, nil)
 
 	dat, err := os.ReadFile("testdata/help-message.txt")
-	if err != nil {
-		t.Fatal("Failed to read data from fixture: ", err)
-	}
+	assert.Ok(t, err)
 
 	res, err := h.Cmd([]string{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Ok(t, err)
 
 	exp := Result{Mesg: strings.Trim(string(dat), "\n")}
-	if res != exp {
-		t.Fatalf("Expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", exp, res)
-	}
-
-	if h.mesg == nil {
-		t.Fatal("Generated doc was not cached.")
-	}
+	assert.Equals(t, res, exp)
+	assert.NotEquals(t, h.mesg, nil)
 }
 
 func TestHelpExtraArgs(t *testing.T) {
 	h := NewHelp([]Cmd{})
 	_, err := h.Cmd([]string{"a", "b"})
-	if err == nil {
-		t.FailNow()
-	}
+	assert.Err(t, err)
 }

--- a/cmd/input_test.go
+++ b/cmd/input_test.go
@@ -1,37 +1,28 @@
 package cmd
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/sanka047/pokedex-go/testing/assert"
 )
 
 func TestInputHappyPath(t *testing.T) {
 	in, err := NewInput("command arg1 arg2")
-	if err != nil {
-		t.FailNow()
-	}
+	assert.Ok(t, err)
 
 	exp := Input{CmdName: "command", Args: []string{"arg1", "arg2"}}
-	if !reflect.DeepEqual(in, exp) {
-		t.Fatalf("Expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", exp, in)
-	}
+	assert.DeepEquals(t, in, exp)
 }
 
 func TestInputNoArgs(t *testing.T) {
 	in, err := NewInput("command")
-	if err != nil {
-		t.FailNow()
-	}
+	assert.Ok(t, err)
 
 	exp := Input{CmdName: "command", Args: []string{}}
-	if !reflect.DeepEqual(in, exp) {
-		t.Fatalf("Expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", exp, in)
-	}
+	assert.DeepEquals(t, in, exp)
 }
 
 func TestInputNoCommand(t *testing.T) {
 	_, err := NewInput("")
-	if err == nil {
-		t.FailNow()
-	}
+	assert.Err(t, err)
 }

--- a/cmd/pokemon_lookup.go
+++ b/cmd/pokemon_lookup.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/sanka047/pokedex-go/pkmn/pokeapi"
+)
+
+type PokemonLookup struct {
+	pokeAPI pokeapi.IPokeAPI
+}
+
+func NewPokemonLookup(p pokeapi.IPokeAPI) *PokemonLookup {
+	return &PokemonLookup{pokeAPI: p}
+}
+
+func (l *PokemonLookup) Name() string {
+	return "pokemon"
+}
+
+func (l *PokemonLookup) Aliases() []string {
+	return []string{"pk"}
+}
+
+func (l *PokemonLookup) Doc() string {
+	return "Lookup a Pokemon by name."
+}
+
+func (l *PokemonLookup) Cmd(args []string) (Result, error) {
+	// TODO: Format this in a more sane way
+	if len(args) != 1 {
+		return Result{}, errors.New(fmt.Sprintf("%s: requires exactly 1 argument (name)", l.Name()))
+	}
+
+	pk, err := l.pokeAPI.GetPokemon(context.Background(), pokeapi.Name(args[0]))
+	if err != nil {
+		return Result{}, err
+	}
+
+	raw, err := json.MarshalIndent(pk, "", "  ")
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Result{Mesg: string(raw)}, nil
+}

--- a/cmd/pokemon_lookup_test.go
+++ b/cmd/pokemon_lookup_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sanka047/pokedex-go/pkmn/pokeapi"
+	"github.com/sanka047/pokedex-go/testing/assert"
+)
+
+type StubPokeAPI struct {}
+
+func (s StubPokeAPI) GetPokemon(ctx context.Context, identifier string) (pokeapi.Pokemon, error) {
+	return pokeapi.Pokemon{}, nil
+}
+
+func TestPokemonLookupHappyPath(t *testing.T) {
+	pl := NewPokemonLookup(StubPokeAPI{})
+
+	res, err := pl.Cmd([]string{"fake-pokemon"})
+	assert.Ok(t, err)
+
+	mesg, err := json.MarshalIndent(pokeapi.Pokemon{}, "", "  ")
+	assert.Ok(t, err)
+
+	exp := Result{Mesg: string(mesg)}
+	assert.Equals(t, res, exp)
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"net/http"
 	"os"
 
 	"github.com/sanka047/pokedex-go/cmd"
+	"github.com/sanka047/pokedex-go/pkmn/pokeapi"
 	"github.com/sanka047/pokedex-go/repl"
 )
 
-func getCommands() []cmd.Cmd {
+func getCommands(pokeAPI *pokeapi.PokeAPI) []cmd.Cmd {
 	cmds := []cmd.Cmd{
 		cmd.NewExit(),
+		cmd.NewPokemonLookup(pokeAPI),
 		// TODO:
 		// - regions
 		// - region <name/id> (sets context)
@@ -23,7 +26,8 @@ func getCommands() []cmd.Cmd {
 }
 
 func main() {
-	r, err := repl.NewRepl(getCommands(), os.Stdin, os.Stdout)
+	pk_api := pokeapi.NewPokeAPI(http.DefaultClient)
+	r, err := repl.NewRepl(getCommands(pk_api), os.Stdin, os.Stdout)
 	if err != nil {
 		panic(err)
 	}

--- a/pkmn/pokeapi/adapter_test.go
+++ b/pkmn/pokeapi/adapter_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/sanka047/pokedex-go/testing/assert"
 )
 
 type RoundTripFunc func(req *http.Request) *http.Response
@@ -22,7 +24,7 @@ func NewTestClient(f RoundTripFunc) *http.Client {
 func TestGetPokemonHappyPath(t *testing.T) {
 	name := "fake-pokemon"
 	client := NewTestClient(func(req *http.Request) *http.Response {
-		equals(t, req.URL.String(), fmt.Sprintf("%s/pokemon/%s", BASE_API_PATH, Name(name)))
+		assert.Equals(t, req.URL.String(), fmt.Sprintf("%s/pokemon/%s", BASE_API_PATH, Name(name)))
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewBufferString("{}")),
@@ -33,13 +35,13 @@ func TestGetPokemonHappyPath(t *testing.T) {
 
 	api := NewPokeAPI(client)
 	_, err := api.GetPokemon(context.Background(), Name(name))
-	ok(t, err)
+	assert.Ok(t, err)
 }
 
 func TestGetPokemonContextDone(t *testing.T) {
 	name := "fake-pokemon"
 	client := NewTestClient(func(req *http.Request) *http.Response {
-		equals(t, req.URL.String(), fmt.Sprintf("%s/pokemon/%s", BASE_API_PATH, Name(name)))
+		assert.Equals(t, req.URL.String(), fmt.Sprintf("%s/pokemon/%s", BASE_API_PATH, Name(name)))
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			// Will fail JSON parsing if read
@@ -55,23 +57,5 @@ func TestGetPokemonContextDone(t *testing.T) {
 
 	api := NewPokeAPI(client)
 	_, err := api.GetPokemon(ctx, Name(name))
-	notEquals(t, err, nil)
-}
-
-func equals(t *testing.T, act, exp any) {
-	if act != exp {
-		t.Fatalf("Expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", exp, act)
-	}
-}
-
-func notEquals(t *testing.T, act, not_exp any) {
-	if act == not_exp {
-		t.Fatalf("Not expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", not_exp, act)
-	}
-}
-
-func ok(t *testing.T, err error) {
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NotEquals(t, err, nil)
 }

--- a/pkmn/pokeapi/model_test.go
+++ b/pkmn/pokeapi/model_test.go
@@ -5,20 +5,22 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/sanka047/pokedex-go/testing/assert"
 )
 
 func TestPokemonSerialization(t *testing.T) {
 	dat, err := os.ReadFile("testdata/pokemon-response.json")
-	ok(t, err)
+	assert.Ok(t, err)
 
 	var pk Pokemon
 	err = json.Unmarshal(dat, &pk)
-	ok(t, err)
+	assert.Ok(t, err)
 
 	exp, err := os.ReadFile("testdata/pokemon-parsed.json")
-	ok(t, err)
+	assert.Ok(t, err)
 
 	act, err := json.MarshalIndent(pk, "", "  ")
-	ok(t, err)
-	equals(t, string(act), strings.Trim(string(exp), "\n"))
+	assert.Ok(t, err)
+	assert.Equals(t, string(act), strings.Trim(string(exp), "\n"))
 }

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -7,46 +7,33 @@ import (
 	"testing/iotest"
 
 	"github.com/sanka047/pokedex-go/cmd"
+	"github.com/sanka047/pokedex-go/testing/assert"
 )
 
 func TestReplHappyPath(t *testing.T) {
 	in, err := os.Open("testdata/repl_input.txt")
-	if err != nil {
-		t.Fatal("Unable to open input fixture file.")
-	}
+	assert.Ok(t, err)
 
 	var out strings.Builder
 
 	r, err := NewRepl([]cmd.Cmd{cmd.Exit{}}, in, &out)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Ok(t, err)
 
-	if r.IsActive() {
-		t.Fatal("REPL did not start in the 'inactive' state.")
-	}
+	assert.False(t, r.IsActive(), "REPL did not start in the 'inactive' state.")
 
 	r.Start()
-	if !r.IsActive() {
-		t.Fatal("REPL should transition to an 'active' state")
-	}
+	assert.True(t, r.IsActive(), "REPL should transition to an 'active' state")
 
 	for r.IsActive() {
 		err = r.Next()
-		if err != nil {
-			t.Fatal(err)
-		}
+		assert.Ok(t, err)
 	}
 
 	exp_out, err := os.Open("testdata/repl_output.txt")
-	if err != nil {
-		t.Fatal("Unable to open output fixture file.")
-	}
+	assert.Ok(t, err)
 
 	err = iotest.TestReader(exp_out, []byte(out.String()))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Ok(t, err)
 }
 
 func TestReplNextOnInactive(t *testing.T) {
@@ -54,16 +41,10 @@ func TestReplNextOnInactive(t *testing.T) {
 	var out strings.Builder
 
 	r, err := NewRepl([]cmd.Cmd{}, in, &out)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Ok(t, err)
 
-	if r.IsActive() {
-		t.Fatal("REPL did not start in the 'inactive' state.")
-	}
+	assert.False(t, r.IsActive(), "REPL did not start in the 'inactive' state.")
 
 	err = r.Next()
-	if err == nil {
-		t.Fatal("Expected error for calling Next without Start.")
-	}
+	assert.Err(t, err)
 }

--- a/testing/assert/assert.go
+++ b/testing/assert/assert.go
@@ -1,0 +1,72 @@
+package assert
+
+import (
+	"reflect"
+	"testing"
+)
+
+// True ensures that the passed in boolean evaluates to true and immediately fails the test
+// otherwise. This accepts variadic arguments that will be immediately passed through to the
+// underlying call to `t.Fatal(args...)`
+func True(t *testing.T, b bool, args ...any) {
+	t.Helper()
+	if !b {
+		t.Fatal(args...)
+	}
+}
+
+// False ensures that the passed in boolean evaluates to false and immediately fails the test
+// otherwise. This accepts variadic arguments that will be immediately passed through to the
+// underlying call to `t.Fatal(args...)`
+func False(t *testing.T, b bool, args ...any) {
+	t.Helper()
+	if b {
+		t.Fatal(args...)
+	}
+}
+
+// Equals ensures that hte actual and expected values are equal and immediately fails the test
+// otherwise.
+//
+// NOTE: This requires the inputs to be comparable. If you need deep comparison of nested fields,
+// see `DeepEquals`.
+func Equals[T comparable](t *testing.T, act, exp T) {
+	t.Helper()
+	if act != exp {
+		t.Fatalf("Expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", exp, act)
+	}
+}
+
+// DeepEquals immediately fails the currently running test if the actual and expected values are not
+// _deeply_ equal (using `reflect.DeepEqual`).
+func DeepEquals(t *testing.T, act, exp any) {
+	t.Helper()
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("Expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", exp, act)
+	}
+}
+
+// NotEquals ensures that the actual and expected values are _not_ equal and immediately fails the
+// test otherwise.
+func NotEquals[T comparable](t *testing.T, act, not_exp T) {
+	t.Helper()
+	if act == not_exp {
+		t.Fatalf("Not expected:\n\"\"\"\n%v\n\"\"\"\nReceived:\n\"\"\"\n%v\n\"\"\"", not_exp, act)
+	}
+}
+
+// Ok ensures that there is _no_ error and immediately fails the test otherwise.
+func Ok(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Err ensures that there _is_ an error and immediately fails the test otherwise.
+func Err(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("Expected error; received nil")
+	}
+}


### PR DESCRIPTION
Adds a very basic pokemon lookup command to interact with PokeAPI. This
is NOT meant to be the final implementation and mainly exists for ease
of testing.

Long-term, this won't be tied to the PokeAPI data model and will be
using our own internal data model for Pokemon since we need to filter
returned data to just what's applicable to the generation/version-group
the user has selected.